### PR TITLE
Add Kurtosis and Mode to addstats in describe()

### DIFF
--- a/tests/testthat/test-describe.R
+++ b/tests/testthat/test-describe.R
@@ -42,3 +42,24 @@ test_that("no grouping", {
 
   expect_equal(nrow(res), 1)
 })
+
+test_that("addstats: Skewness, Kurtosis, Mode", {
+  expect_no_error(res <- df %>%
+                    group_by(group) %>%
+                    BioMathR::describe("weight", addstats = c("Skewness", "Kurtosis", "Mode")))
+
+  expect_true("Skewness" %in% names(res))
+  expect_true("Kurtosis" %in% names(res))
+  expect_true("Mode" %in% names(res))
+  expect_equal(ncol(res), 13)  # Variable + group + N + Miss + Mean + StdDev + IQR + Min + Median + Max + Skewness + Kurtosis + Mode
+})
+
+test_that("addstats with German language", {
+  expect_no_error(res <- df %>%
+                    group_by(group) %>%
+                    BioMathR::describe("weight", lang = "ger", addstats = c("Skewness", "Kurtosis", "Mode")))
+
+  expect_true("Schiefe" %in% names(res))
+  expect_true("Kurtosis" %in% names(res))  # Same in German
+  expect_true("Modus" %in% names(res))
+})


### PR DESCRIPTION
Resolves #7 by implementing the requested additional statistics.

Changes:
- Added "Kurtosis" and "Mode" to supported addstats options
- Implemented mode_fn() helper to calculate the most frequent value
- Added Kurtosis using e1071::kurtosis (same as Skewness)
- Updated documentation to list all three addstats options
- Added German translations: "Modus" for Mode, "Kurtosis" stays same
- Added comprehensive tests for both English and German

The naming conflict mentioned in the issue was already fixed (function uses "temp_names" not "name", and test passes).

This commit completes the addstats improvement requested in the June 1, 2023 comment on the issue.