### PR TITLE
Fix desc_tabs() to apply independent color scales per variable

### DIFF
--- a/R/cond_format.R
+++ b/R/cond_format.R
@@ -5,6 +5,7 @@
 #' @param wb a Workbook object
 #' @param sheetName a name or index of a worksheet
 #' @param columns column names or indices to apply conditional formatting to
+#' @param rows optional row indices to apply conditional formatting to. If NULL (default), applies to all data rows.
 #' @param colourScale shortcut argument to apply "colourScale" formatting, e.g. \code{c("red" = 0, "grey" = 50, "green" = 100)}
 #' @param contains shortcut argument to apply "contains" formatting, e.g. \code{"word"}
 #' @param expression shortcut argument to apply "expression" formatting, e.g. \code{">=50"}
@@ -20,6 +21,7 @@
 cond_format <- function(wb,
                         sheetName = NULL,
                         columns,
+                        rows = NULL,  # Optional: specific rows to format (default: all rows)
                         colourScale = NULL, # c("red" = 0, "grey" = 50, "green" = 100)
                         contains = NULL, # "word"
                         expression = NULL, # ">=50"
@@ -41,7 +43,12 @@ cond_format <- function(wb,
   }
 
   # get row index for rows to be conditionally formatted
-  rowindex <- seq_len(nrow(dat_copy)) + 1
+  # If rows parameter is provided, use it; otherwise format all data rows
+  if (!is.null(rows)) {
+    rowindex <- rows
+  } else {
+    rowindex <- seq_len(nrow(dat_copy)) + 1
+  }
 
 
   # docolourScale -----------------------------------------------------------

--- a/R/desc_tabs.R
+++ b/R/desc_tabs.R
@@ -45,14 +45,38 @@ desc_tabs <-
                             sheetName = comb_ij_lab,
                             data = comb_ij_tab)
 
-        BioMathR::cond_format(
-          wb = wb,
-          sheetName = comb_ij_lab,
-          columns = which(names(comb_ij_tab) %in% c("MW", "Mean"), arr.ind = TRUE),
-          style = c("#ed6a5a", "#f0a202", "#00923f"),
-          rule = NULL,
-          type = "colourScale"
-        )
+        # Apply conditional formatting separately for each variable to handle different scales
+        if ("Variable" %in% names(comb_ij_tab)) {
+          # Get unique variables
+          unique_vars <- unique(comb_ij_tab$Variable)
+
+          # Apply conditional formatting for each variable's rows separately
+          for (var in unique_vars) {
+            # Get row indices for this variable (add 1 for header row in Excel)
+            var_rows <- which(comb_ij_tab$Variable == var) + 1
+
+            # Apply color scale only to this variable's rows
+            BioMathR::cond_format(
+              wb = wb,
+              sheetName = comb_ij_lab,
+              columns = which(names(comb_ij_tab) %in% c("MW", "Mean"), arr.ind = TRUE),
+              style = c("#ed6a5a", "#f0a202", "#00923f"),
+              rule = NULL,
+              type = "colourScale",
+              rows = var_rows  # Only format rows for this specific variable
+            )
+          }
+        } else {
+          # Fallback: if no Variable column, apply formatting to all rows as before
+          BioMathR::cond_format(
+            wb = wb,
+            sheetName = comb_ij_lab,
+            columns = which(names(comb_ij_tab) %in% c("MW", "Mean"), arr.ind = TRUE),
+            style = c("#ed6a5a", "#f0a202", "#00923f"),
+            rule = NULL,
+            type = "colourScale"
+          )
+        }
       }
     }
 


### PR DESCRIPTION
Resolves #8 by applying conditional formatting separately for each variable's rows instead of to the entire column.

Problem:
When multiple yvars with different scales (e.g., 0-10 and 0-1000) were displayed in the same sheet, they shared ONE color scale applied to the entire "Mean" column. This made the formatting misleading as small and large values appeared similarly colored.

Solution:
1. Updated desc_tabs() to detect unique variables in each sheet
2. For each variable, apply conditional formatting only to its rows
3. Each variable now gets an independent color scale based on its own min/max values, not the global min/max across all variables

Implementation:
- Added optional `rows` parameter to cond_format() function
- Modified desc_tabs() to loop through variables and apply formatting to specific row ranges for each variable
- Added fallback for cases without Variable column (backward compat)
- Updated cond_format() documentation

Result: Variables with different scales now display meaningful color gradients that reflect their individual data distributions.